### PR TITLE
Chore: Raise swift-crypto, certificates, and asn1 floors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,7 @@ coverage.txt
 coverage-*.lcov
 signing-server.log
 test-results.json
+
+# Claude
+CLAUDE.md
+.claude/*

--- a/Library/Library.xcodeproj/project.pbxproj
+++ b/Library/Library.xcodeproj/project.pbxproj
@@ -794,7 +794,7 @@
 			repositoryURL = "https://github.com/apple/swift-certificates.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 1.12.0;
+				minimumVersion = 1.19.4;
 			};
 		};
 		9534697F2E4CB0A8003E83AD /* XCRemoteSwiftPackageReference "swift-crypto" */ = {
@@ -802,7 +802,7 @@
 			repositoryURL = "https://github.com/apple/swift-crypto.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 3.14.0;
+				minimumVersion = 4.5.1;
 			};
 		};
 		953469842E4CB0CE003E83AD /* XCRemoteSwiftPackageReference "swift-log" */ = {
@@ -818,7 +818,7 @@
 			repositoryURL = "https://github.com/apple/swift-asn1.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 1.4.0;
+				minimumVersion = 1.7.1;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Package.dev.swift
+++ b/Package.dev.swift
@@ -26,9 +26,10 @@ let package = Package(
     ],
     dependencies: [
         .package(
-            url: "https://github.com/apple/swift-certificates.git", .upToNextMajor(from: "1.0.0")),
-        .package(url: "https://github.com/apple/swift-asn1.git", .upToNextMajor(from: "1.0.0")),
-        .package(url: "https://github.com/apple/swift-crypto.git", .upToNextMajor(from: "3.0.0")),
+            url: "https://github.com/apple/swift-certificates.git", .upToNextMajor(from: "1.19.4")),
+        .package(url: "https://github.com/apple/swift-asn1.git", .upToNextMajor(from: "1.7.1")),
+        // 4.5.1 is the lowest version outside the CVE-2026-43823 range (>= 3.2.0, <= 4.5.0).
+        .package(url: "https://github.com/apple/swift-crypto.git", .upToNextMajor(from: "4.5.1")),
     ],
     targets: [
         .binaryTarget(

--- a/Package.swift
+++ b/Package.swift
@@ -26,9 +26,10 @@ let package = Package(
     ],
     dependencies: [
         .package(
-            url: "https://github.com/apple/swift-certificates.git", .upToNextMajor(from: "1.0.0")),
-        .package(url: "https://github.com/apple/swift-asn1.git", .upToNextMajor(from: "1.0.0")),
-        .package(url: "https://github.com/apple/swift-crypto.git", .upToNextMajor(from: "3.0.0"))
+            url: "https://github.com/apple/swift-certificates.git", .upToNextMajor(from: "1.19.4")),
+        .package(url: "https://github.com/apple/swift-asn1.git", .upToNextMajor(from: "1.7.1")),
+        // 4.5.1 is the lowest version outside the CVE-2026-43823 range (>= 3.2.0, <= 4.5.0).
+        .package(url: "https://github.com/apple/swift-crypto.git", .upToNextMajor(from: "4.5.1"))
     ],
     targets: [
         .binaryTarget(

--- a/SigningServer/Package.swift
+++ b/SigningServer/Package.swift
@@ -22,9 +22,10 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/vapor/vapor.git", from: "4.89.0"),
-        .package(url: "https://github.com/apple/swift-certificates.git", from: "1.0.0"),
-        .package(url: "https://github.com/apple/swift-asn1.git", from: "1.0.0"),
-        .package(url: "https://github.com/apple/swift-crypto.git", from: "3.0.0")
+        .package(url: "https://github.com/apple/swift-certificates.git", from: "1.19.4"),
+        .package(url: "https://github.com/apple/swift-asn1.git", from: "1.7.1"),
+        // 4.5.1 is the lowest version outside the CVE-2026-43823 range (>= 3.2.0, <= 4.5.0).
+        .package(url: "https://github.com/apple/swift-crypto.git", from: "4.5.1")
     ],
     targets: [
         .executableTarget(


### PR DESCRIPTION
## Changes in this pull request
<!-- Give a description of what has changed -->
Raises swift-crypto to 4.5.1, swift-certificates to 1.19.4, swift-asn1 to 1.7.1. The old `< 4.0.0` cap blocked the fix for CVE-2026-43823 (critical RSA double-free).

Refs: https://github.com/contentauth/c2pa-swift/issues/139
## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] All applicable changes have been documented
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment