### PR TITLE
Fix: Accidental truncation in withCStringArray

### DIFF
--- a/Library/Sources/C2PAError.swift
+++ b/Library/Sources/C2PAError.swift
@@ -36,9 +36,10 @@ import Foundation
 /// - ``asyncSigningFailed``
 /// - ``manifestValidationFailed(_:)``
 public enum C2PAError: Error, LocalizedError {
-    /// An error reported by the underlying C2PA library.
+    /// An error reported by the underlying C2PA library, or by the Swift wrapper
+    /// while marshalling data across the C boundary.
     ///
-    /// - Parameter message: The error message from the Rust/C layer.
+    /// - Parameter message: The error message from the Rust/C layer or the wrapper.
     case api(_ message: String)
 
     /// An unexpected NULL pointer was encountered in the C API.

--- a/Library/Sources/Helpers.swift
+++ b/Library/Sources/Helpers.swift
@@ -111,14 +111,22 @@ func manifestData(length: Int64, pointer: UnsafePointer<UInt8>?) -> Data {
 /// Invokes `body` with a NULL-terminated C string array built from `strings`
 /// (or `nil` when `strings` is empty). The array and its strings are valid only
 /// for the duration of `body`.
+///
+/// - Throws: ``C2PAError`` if any string could not be duplicated. A failed `strdup`
+///   would otherwise leave a NULL in the middle of the array, which the C layer reads
+///   as the terminator and so silently truncates the list.
 func withCStringArray<R>(
     _ strings: [String],
     _ body: (UnsafePointer<UnsafePointer<CChar>?>?) throws -> R
-) rethrows -> R {
+) throws -> R {
     guard !strings.isEmpty else { return try body(nil) }
     var cStrings: [UnsafePointer<CChar>?] = strings.map { UnsafePointer(strdup($0)) }
     cStrings.append(nil)
+    // Installed before the allocation check so partial allocations are freed when it throws.
     defer { for p in cStrings where p != nil { free(UnsafeMutablePointer(mutating: p)) } }
+    guard !cStrings.dropLast().contains(where: { $0 == nil }) else {
+        throw C2PAError.api("Failed to allocate C string array")
+    }
     return try cStrings.withUnsafeBufferPointer { try body($0.baseAddress) }
 }
 

--- a/Library/Sources/Signer.swift
+++ b/Library/Sources/Signer.swift
@@ -448,13 +448,15 @@ public final class Signer {
         }
         let claimPtr = try claimSigner.livePtr()
         let identityPtr = try identitySigner.livePtr()
-        // The native call invalidates both inputs unconditionally, so mark them consumed
-        // before it runs: on failure that leaks rather than risking a double free.
-        claimSigner.consumed = true
-        identitySigner.consumed = true
         let raw = try withCStringArray(referencedAssertions) { refs in
             try withCStringArray(roles) { roleList in
-                try guardNotNull(
+                // The native call invalidates both inputs unconditionally, so mark them
+                // consumed immediately before it runs: on failure that leaks rather than
+                // risking a double free. Marking them any earlier would also leak them when
+                // withCStringArray throws before the native call ever happens.
+                claimSigner.consumed = true
+                identitySigner.consumed = true
+                return try guardNotNull(
                     c2pa_identity_signer_create(claimPtr, identityPtr, refs, roleList))
             }
         }

--- a/Library/Tests/LibraryTestRunner.swift
+++ b/Library/Tests/LibraryTestRunner.swift
@@ -1077,3 +1077,38 @@ final class SettingsDefinitionTests: XCTestCase {
     }
 }
 
+
+// MARK: - Helpers Tests
+
+// These exercise internal helpers directly, so they live here rather than in the
+// shared TestShared target, which only sees the public surface.
+final class CStringArrayTests: XCTestCase {
+
+    func testEmptyArrayPassesNull() throws {
+        let wasNil = try withCStringArray([]) { $0 == nil }
+        XCTAssertTrue(wasNil, "an empty array should pass NULL rather than an empty list")
+    }
+
+    func testStringsAreNullTerminated() throws {
+        let input = ["c2pa.actions", "cawg.training-mining"]
+        let readBack = try withCStringArray(input) { pointer -> [String] in
+            guard let pointer else { return [] }
+            var result: [String] = []
+            var index = 0
+            // Read until the terminator, exactly as the C layer does.
+            while let element = pointer[index] {
+                result.append(String(cString: element))
+                index += 1
+            }
+            return result
+        }
+        XCTAssertEqual(readBack, input, "the C layer must see every string, in order")
+    }
+
+    func testBodyErrorPropagates() {
+        struct Sentinel: Error {}
+        XCTAssertThrowsError(try withCStringArray(["a"]) { _ -> Int in throw Sentinel() }) { error in
+            XCTAssertTrue(error is Sentinel, "an error thrown by body should reach the caller unchanged")
+        }
+    }
+}


### PR DESCRIPTION
## Changes in this pull request
<!-- Give a description of what has changed -->

A failed `strdup` in `withCStringArray` left a NULL mid-array, which the C layer reads as the terminator and so silently truncates the list. Now throws instead.

Raised by @scouten-adobe in review of #148.
## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] All applicable changes have been documented
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment