### PR TITLE
feat(manifest): preserve unknown fields and accept the OS alias

### DIFF
--- a/Library/Sources/Manifest/AdditionalFields.swift
+++ b/Library/Sources/Manifest/AdditionalFields.swift
@@ -1,0 +1,70 @@
+// This file is licensed to you under the Apache License, Version 2.0
+// (http://www.apache.org/licenses/LICENSE-2.0) or the MIT license
+// (http://opensource.org/licenses/MIT), at your option.
+//
+// Unless required by applicable law or agreed to in writing, this software is
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS OF
+// ANY KIND, either express or implied. See the LICENSE-MIT and LICENSE-APACHE
+// files for the specific language governing permissions and limitations under
+// each license.
+//
+//  AdditionalFields.swift
+//
+
+import Foundation
+
+/// A coding key for JSON members that have no matching property.
+///
+/// Swift's synthesized `Codable` drops unrecognized members, whereas the c2pa-rs
+/// structs these models mirror capture them in a `#[serde(flatten)]` map. Decoding
+/// through this key lets a model round-trip fields it does not itself understand.
+struct AdditionalFieldsCodingKey: CodingKey {
+    let stringValue: String
+
+    var intValue: Int? { nil }
+
+    init(_ stringValue: String) {
+        self.stringValue = stringValue
+    }
+
+    init?(stringValue: String) {
+        self.init(stringValue)
+    }
+
+    init?(intValue: Int) {
+        nil
+    }
+}
+
+extension Decoder {
+    /// Collects every member whose key is not in `known`.
+    ///
+    /// - Parameter known: Keys the model decodes into its own properties, including any
+    ///   alias it accepts. Passing an incomplete set would duplicate a known field into
+    ///   the additional-fields map and re-encode it twice.
+    ///
+    /// - Returns: The unrecognized members, or `nil` when there are none, so a model
+    ///   that saw no extras encodes nothing rather than an empty object.
+    func decodeAdditionalFields(excluding known: Set<String>) throws -> [String: AnyCodable]? {
+        let container = try self.container(keyedBy: AdditionalFieldsCodingKey.self)
+        var fields: [String: AnyCodable] = [:]
+        for key in container.allKeys where !known.contains(key.stringValue) {
+            fields[key.stringValue] = try container.decode(AnyCodable.self, forKey: key)
+        }
+        return fields.isEmpty ? nil : fields
+    }
+}
+
+extension Encoder {
+    /// Writes previously unrecognized members back alongside the model's own keys.
+    ///
+    /// Keys in `known` are skipped: the model has already encoded those itself, and
+    /// encoding the same key twice into one container traps at runtime.
+    func encodeAdditionalFields(_ fields: [String: AnyCodable]?, excluding known: Set<String>) throws {
+        guard let fields, !fields.isEmpty else { return }
+        var container = self.container(keyedBy: AdditionalFieldsCodingKey.self)
+        for (key, value) in fields where !known.contains(key) {
+            try container.encode(value, forKey: AdditionalFieldsCodingKey(key))
+        }
+    }
+}

--- a/Library/Sources/Manifest/ClaimGeneratorInfo.swift
+++ b/Library/Sources/Manifest/ClaimGeneratorInfo.swift
@@ -21,12 +21,18 @@ import UIKit
 /// - SeeAlso: [ClaimGeneratorInfo Reference](https://opensource.contentauthenticity.org/docs/manifest/json-ref/manifest-definition-schema#claimgeneratorinfo)
 public struct ClaimGeneratorInfo: Codable, Equatable {
 
-    public enum CodingKeys: String, CodingKey {
+    public enum CodingKeys: String, CodingKey, CaseIterable {
         case icon
         case name
         case operatingSystem = "operating_system"
         case version
     }
+
+    /// The alternate spelling c2pa-rs accepts for ``operatingSystem`` when decoding.
+    /// It always writes `operating_system`, so this is only ever read, never written.
+    static let operatingSystemAlias = "schema.org.SoftwareApplication.operatingSystem"
+
+    private static let knownKeys = Set(CodingKeys.allCases.map(\.rawValue) + [operatingSystemAlias])
 
     /// Hashed URI to the icon (either embedded or remote).
     public var icon: UriOrResource?
@@ -40,6 +46,12 @@ public struct ClaimGeneratorInfo: Codable, Equatable {
     /// A human readable string of the product’s version
     public var version: String?
 
+    /// Members of the decoded object that this type does not model.
+    ///
+    /// c2pa-rs keeps these in a flattened map, so a manifest written by another
+    /// generator survives a decode/encode cycle here rather than losing them.
+    public var additionalFields: [String: AnyCodable]?
+
     /// - Parameters:
     ///   - icon: Hashed URI to the icon (either embedded or remote).
     ///   - name: A human readable string naming the claim_generator. *(This is automatically evaluated by default. You should not set this yourself!)*
@@ -49,12 +61,40 @@ public struct ClaimGeneratorInfo: Codable, Equatable {
         icon: UriOrResource? = nil,
         name: String = ClaimGeneratorInfo.appName,
         operatingSystem: String? = nil,
-        version: String? = ClaimGeneratorInfo.appVersion
+        version: String? = ClaimGeneratorInfo.appVersion,
+        additionalFields: [String: AnyCodable]? = nil
     ) {
         self.icon = icon
         self.name = name
         self.operatingSystem = operatingSystem
         self.version = version
+        self.additionalFields = additionalFields
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        icon = try container.decodeIfPresent(UriOrResource.self, forKey: .icon)
+        name = try container.decode(String.self, forKey: .name)
+        version = try container.decodeIfPresent(String.self, forKey: .version)
+
+        if let value = try container.decodeIfPresent(String.self, forKey: .operatingSystem) {
+            operatingSystem = value
+        } else {
+            let aliased = try decoder.container(keyedBy: AdditionalFieldsCodingKey.self)
+            operatingSystem = try aliased.decodeIfPresent(
+                String.self, forKey: AdditionalFieldsCodingKey(Self.operatingSystemAlias))
+        }
+
+        additionalFields = try decoder.decodeAdditionalFields(excluding: Self.knownKeys)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(icon, forKey: .icon)
+        try container.encode(name, forKey: .name)
+        try container.encodeIfPresent(operatingSystem, forKey: .operatingSystem)
+        try container.encodeIfPresent(version, forKey: .version)
+        try encoder.encodeAdditionalFields(additionalFields, excluding: Self.knownKeys)
     }
 
 #if os(macOS)

--- a/Library/Sources/Manifest/Metadata.swift
+++ b/Library/Sources/Manifest/Metadata.swift
@@ -19,6 +19,16 @@ import Foundation
 /// - SeeAlso: [Metadata Reference](https://opensource.contentauthenticity.org/docs/manifest/json-ref/manifest-definition-schema#metadata)
 public struct Metadata: Codable, Equatable {
 
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case dataSource
+        case dateTime
+        case reference
+        case regionOfInterest
+        case reviewRatings
+    }
+
+    private static let knownKeys = Set(CodingKeys.allCases.map(\.rawValue))
+
     public var dataSource: DataSource?
 
     public var dateTime: Date?
@@ -29,17 +39,45 @@ public struct Metadata: Codable, Equatable {
 
     public var reviewRatings: [ReviewRating]?
 
+    /// Members of the decoded object that this type does not model.
+    ///
+    /// The C2PA metadata object is explicitly open-ended and c2pa-rs keeps these in a
+    /// flattened map, so they survive a decode/encode cycle here rather than being lost.
+    public var additionalFields: [String: AnyCodable]?
+
     public init(
         dataSource: DataSource? = nil,
         dateTime: Date? = nil,
         reference: HashedUri? = nil,
         regionOfInterest: RegionOfInterest? = nil,
-        reviewRatings: [ReviewRating]? = nil
+        reviewRatings: [ReviewRating]? = nil,
+        additionalFields: [String: AnyCodable]? = nil
     ) {
         self.dataSource = dataSource
         self.dateTime = dateTime
         self.reference = reference
         self.regionOfInterest = regionOfInterest
         self.reviewRatings = reviewRatings
+        self.additionalFields = additionalFields
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        dataSource = try container.decodeIfPresent(DataSource.self, forKey: .dataSource)
+        dateTime = try container.decodeIfPresent(Date.self, forKey: .dateTime)
+        reference = try container.decodeIfPresent(HashedUri.self, forKey: .reference)
+        regionOfInterest = try container.decodeIfPresent(RegionOfInterest.self, forKey: .regionOfInterest)
+        reviewRatings = try container.decodeIfPresent([ReviewRating].self, forKey: .reviewRatings)
+        additionalFields = try decoder.decodeAdditionalFields(excluding: Self.knownKeys)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(dataSource, forKey: .dataSource)
+        try container.encodeIfPresent(dateTime, forKey: .dateTime)
+        try container.encodeIfPresent(reference, forKey: .reference)
+        try container.encodeIfPresent(regionOfInterest, forKey: .regionOfInterest)
+        try container.encodeIfPresent(reviewRatings, forKey: .reviewRatings)
+        try encoder.encodeAdditionalFields(additionalFields, excluding: Self.knownKeys)
     }
 }

--- a/Library/Tests/LibraryTestRunner.swift
+++ b/Library/Tests/LibraryTestRunner.swift
@@ -530,6 +530,18 @@ final class ManifestTests: XCTestCase {
         let result = tests.testManifestWireKeyDrift()
         XCTAssertTrue(result.passed, result.message)
     }
+    func testClaimGeneratorInfoPreservesUnknownFields() throws {
+        let result = tests.testClaimGeneratorInfoPreservesUnknownFields()
+        XCTAssertTrue(result.passed, result.message)
+    }
+    func testClaimGeneratorInfoOperatingSystemAlias() throws {
+        let result = tests.testClaimGeneratorInfoOperatingSystemAlias()
+        XCTAssertTrue(result.passed, result.message)
+    }
+    func testMetadataPreservesUnknownFields() throws {
+        let result = tests.testMetadataPreservesUnknownFields()
+        XCTAssertTrue(result.passed, result.message)
+    }
     func testValidateAndLog() throws {
         XCTAssertTrue(tests.testValidateAndLog().passed)
     }

--- a/TestShared/Sources/ManifestTests.swift
+++ b/TestShared/Sources/ManifestTests.swift
@@ -540,6 +540,99 @@ public final class ManifestTests: TestImplementation {
             "Wire Key Drift", "[PASS] \(checks.count) models match their c2pa-rs wire keys")
     }
 
+    public func testClaimGeneratorInfoPreservesUnknownFields() -> TestResult {
+        // c2pa-rs keeps unrecognized members in a flattened map, so a manifest written by
+        // another generator must survive a decode/encode cycle here rather than losing them.
+        let source = """
+        {"name":"Other/1.0","operating_system":"iOS 18",\
+        "vendorSpecific":{"channel":"beta"},"buildCount":7}
+        """
+        do {
+            let decoded = try JSONDecoder().decode(ClaimGeneratorInfo.self, from: Data(source.utf8))
+            guard let extras = decoded.additionalFields else {
+                return .failure("CGI Unknown Fields", "additionalFields should not be nil")
+            }
+            guard Set(extras.keys) == ["vendorSpecific", "buildCount"] else {
+                return .failure("CGI Unknown Fields", "unexpected extras: \(extras.keys.sorted())")
+            }
+            guard decoded.additionalFields?["name"] == nil else {
+                return .failure("CGI Unknown Fields", "a modeled key leaked into additionalFields")
+            }
+
+            let reencoded = try JSONEncoder().encode(decoded)
+            let json = String(data: reencoded, encoding: .utf8) ?? ""
+            for key in ["\"vendorSpecific\"", "\"buildCount\"", "\"operating_system\""] where !json.contains(key) {
+                return .failure("CGI Unknown Fields", "re-encoded JSON dropped \(key): \(json)")
+            }
+
+            // Decoding the re-encoded form must land in the same place.
+            let again = try JSONDecoder().decode(ClaimGeneratorInfo.self, from: reencoded)
+            guard again == decoded else {
+                return .failure("CGI Unknown Fields", "round-trip is not stable")
+            }
+        } catch {
+            return .failure("CGI Unknown Fields", "Error: \(error)")
+        }
+        return .success("CGI Unknown Fields", "[PASS] unknown fields survive the round-trip")
+    }
+
+    public func testClaimGeneratorInfoOperatingSystemAlias() -> TestResult {
+        // c2pa-rs accepts the schema.org spelling when decoding but always writes
+        // operating_system, so decoding must accept both and encoding must normalize.
+        let aliased = """
+        {"name":"Other/1.0","schema.org.SoftwareApplication.operatingSystem":"macOS 15"}
+        """
+        do {
+            let decoded = try JSONDecoder().decode(ClaimGeneratorInfo.self, from: Data(aliased.utf8))
+            guard decoded.operatingSystem == "macOS 15" else {
+                return .failure(
+                    "CGI OS Alias", "alias did not decode, got \(decoded.operatingSystem ?? "nil")")
+            }
+            guard decoded.additionalFields == nil else {
+                return .failure("CGI OS Alias", "the alias key leaked into additionalFields")
+            }
+
+            let json = String(data: try JSONEncoder().encode(decoded), encoding: .utf8) ?? ""
+            guard json.contains("\"operating_system\"") else {
+                return .failure("CGI OS Alias", "did not re-encode as operating_system: \(json)")
+            }
+            guard !json.contains("schema.org") else {
+                return .failure("CGI OS Alias", "re-encoded using the alias spelling: \(json)")
+            }
+        } catch {
+            return .failure("CGI OS Alias", "Error: \(error)")
+        }
+        return .success("CGI OS Alias", "[PASS] alias decodes and normalizes to operating_system")
+    }
+
+    public func testMetadataPreservesUnknownFields() -> TestResult {
+        // The C2PA metadata object is explicitly open-ended.
+        let source = """
+        {"dataSource":{"type":"signer"},"org.example.custom":"kept","weight":3}
+        """
+        do {
+            let decoded = try JSONDecoder().decode(Metadata.self, from: Data(source.utf8))
+            guard let extras = decoded.additionalFields,
+                Set(extras.keys) == ["org.example.custom", "weight"]
+            else {
+                return .failure(
+                    "Metadata Unknown Fields",
+                    "unexpected extras: \(decoded.additionalFields?.keys.sorted() ?? [])")
+            }
+            guard decoded.dataSource?.type == "signer" else {
+                return .failure("Metadata Unknown Fields", "modeled dataSource did not decode")
+            }
+
+            let json = String(data: try JSONEncoder().encode(decoded), encoding: .utf8) ?? ""
+            for key in ["\"org.example.custom\"", "\"weight\"", "\"dataSource\""] where !json.contains(key) {
+                return .failure("Metadata Unknown Fields", "re-encoded JSON dropped \(key): \(json)")
+            }
+        } catch {
+            return .failure("Metadata Unknown Fields", "Error: \(error)")
+        }
+        return .success("Metadata Unknown Fields", "[PASS] unknown fields survive the round-trip")
+    }
+
     public func testValidateAndLog() -> TestResult {
         let manifest = ManifestDefinition(
             claimGeneratorInfo: [ClaimGeneratorInfo()],
@@ -910,6 +1003,9 @@ public final class ManifestTests: TestImplementation {
             testActionNewFields(),
             testActionWireKeys(),
             testManifestWireKeyDrift(),
+            testClaimGeneratorInfoPreservesUnknownFields(),
+            testClaimGeneratorInfoOperatingSystemAlias(),
+            testMetadataPreservesUnknownFields(),
             testValidateAndLog(),
             testCustomAssertionLabelValidation(),
             testCreatedFactory(),


### PR DESCRIPTION
ClaimGeneratorInfo and Metadata mirror c2pa-rs structs that keep unrecognized members in a flattened map. Swift's synthesized Codable drops them instead, so decoding a manifest from another generator and re-encoding it silently lost every field we do not model. Both types now capture them in additionalFields and write them back.

ClaimGeneratorInfo also accepts the schema.org spelling of operatingSystem that c2pa-rs takes as a decode alias, and normalizes it back to operating_system on encode, which is the only form c2pa-rs writes. The alias is excluded from additionalFields so it cannot be emitted twice.

Add AdditionalFieldsCodingKey with Decoder and Encoder helpers, shared by both types. The helpers skip keys the model already handles: encoding the same key into one container twice traps at runtime.

## Changes in this pull request
<!-- Give a description of what has changed -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] All applicable changes have been documented
- [ ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment