### PR TITLE
Feat: Add progress and HTTP resolver callbacks

### DIFF
--- a/Library/Sources/C2PAContext.swift
+++ b/Library/Sources/C2PAContext.swift
@@ -14,6 +14,170 @@
 import C2PAC
 import Foundation
 
+/// A phase of a C2PA signing or reading operation. Maps the native `C2paProgressPhase`.
+public enum ProgressPhase: Sendable {
+    case reading, verifyingManifest, verifyingSignature, verifyingIngredient,
+         verifyingAssetHash, addingIngredient, thumbnail, hashing, signing,
+         embedding, fetchingRemoteManifest, writing, fetchingOCSP, fetchingTimestamp
+
+    /// A phase value not known to this version of the wrapper.
+    case unknown
+
+    init(_ phase: C2paProgressPhase) {
+        switch phase {
+        case Reading: self = .reading
+        case VerifyingManifest: self = .verifyingManifest
+        case VerifyingSignature: self = .verifyingSignature
+        case VerifyingIngredient: self = .verifyingIngredient
+        case VerifyingAssetHash: self = .verifyingAssetHash
+        case AddingIngredient: self = .addingIngredient
+        case Thumbnail: self = .thumbnail
+        case Hashing: self = .hashing
+        case Signing: self = .signing
+        case Embedding: self = .embedding
+        case FetchingRemoteManifest: self = .fetchingRemoteManifest
+        case Writing: self = .writing
+        case FetchingOCSP: self = .fetchingOCSP
+        case FetchingTimestamp: self = .fetchingTimestamp
+        default: self = .unknown
+        }
+    }
+}
+
+/// A progress update delivered during a signing or reading operation.
+public struct ProgressUpdate: Sendable {
+    /// The current operation phase.
+    public let phase: ProgressPhase
+
+    /// Monotonically increasing within a phase (starts at 1); rising values indicate liveness.
+    public let step: UInt32
+
+    /// `0` = indeterminate, `1` = single-shot, `> 1` = determinate (`step` of `total`).
+    public let total: UInt32
+}
+
+/// An HTTP request the SDK needs resolved (remote manifest, OCSP, or timestamp fetch).
+public struct HTTPRequest: Sendable {
+    /// The request URL.
+    public let url: URL
+
+    /// The HTTP method (e.g. `"GET"`).
+    public let method: String
+
+    /// Request headers.
+    public let headers: [String: String]
+
+    /// The request body, if any.
+    public let body: Data?
+}
+
+/// The HTTP response a resolver returns.
+public struct HTTPResponse: Sendable {
+    /// The HTTP status code.
+    public let status: Int
+
+    /// The response body.
+    public let body: Data
+
+    public init(status: Int, body: Data) {
+        self.status = status
+        self.body = body
+    }
+}
+
+private final class ProgressCallbackBox {
+    let onProgress: (ProgressUpdate) -> Void
+
+    init(_ onProgress: @escaping (ProgressUpdate) -> Void) {
+        self.onProgress = onProgress
+    }
+}
+
+/// Carries a resolver result across the `URLSession` completion boundary.
+///
+/// The completion handler is `@Sendable`, so the result cannot be written into captured
+/// local state. Mirrors the pattern already used by ``WebServiceSigner``.
+private final class HTTPResultBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var result: Result<HTTPResponse, Error>?
+
+    func set(_ value: Result<HTTPResponse, Error>) {
+        lock.lock()
+        defer { lock.unlock() }
+        result = value
+    }
+
+    func get() -> Result<HTTPResponse, Error>? {
+        lock.lock()
+        defer { lock.unlock() }
+        return result
+    }
+}
+
+private final class HTTPResolverBox {
+    let resolve: (HTTPRequest) throws -> HTTPResponse
+
+    init(_ resolve: @escaping (HTTPRequest) throws -> HTTPResponse) {
+        self.resolve = resolve
+    }
+}
+
+/// Observes progress and always continues; cancellation is via ``C2PAContext/cancel()``.
+private let progressTrampoline: ProgressCCallback = { context, phase, step, total in
+    guard let context else { return 1 }
+    let box = Unmanaged<ProgressCallbackBox>.fromOpaque(context).takeUnretainedValue()
+    box.onProgress(ProgressUpdate(phase: ProgressPhase(phase), step: step, total: total))
+    return 1
+}
+
+/// Resolves one request. May run on any thread, so the boxed closure must be thread-safe.
+private let httpResolverTrampoline: C2paHttpResolverCallback = { context, request, response in
+    guard let context, let request, let response else { return 1 }
+    let box = Unmanaged<HTTPResolverBox>.fromOpaque(context).takeUnretainedValue()
+    let incoming = request.pointee
+
+    guard let urlPtr = incoming.url, let url = URL(string: String(cString: urlPtr)) else {
+        _ = "Invalid request URL".withCString { c2pa_error_set_last($0) }
+        return 1
+    }
+
+    let method = incoming.method.map { String(cString: $0) } ?? "GET"
+    var headers: [String: String] = [:]
+    if let rawHeaders = incoming.headers {
+        for line in String(cString: rawHeaders).split(separator: "\n") {
+            guard let separator = line.firstIndex(of: ":") else { continue }
+            let name = String(line[..<separator]).trimmingCharacters(in: .whitespaces)
+            let value = String(line[line.index(after: separator)...]).trimmingCharacters(in: .whitespaces)
+            if !name.isEmpty { headers[name] = value }
+        }
+    }
+    let body: Data? = (incoming.body != nil && incoming.body_len > 0)
+        ? Data(bytes: incoming.body!, count: Int(incoming.body_len)) : nil
+
+    do {
+        let result = try box.resolve(
+            HTTPRequest(url: url, method: method, headers: headers, body: body))
+        response.pointee.status = Int32(result.status)
+        if result.body.isEmpty {
+            response.pointee.body = nil
+            response.pointee.body_len = 0
+        } else {
+            // Rust takes ownership of this allocation and frees it.
+            guard let buffer = malloc(result.body.count)?.assumingMemoryBound(to: UInt8.self) else {
+                _ = "Failed to allocate response body".withCString { c2pa_error_set_last($0) }
+                return 1
+            }
+            result.body.copyBytes(to: buffer, count: result.body.count)
+            response.pointee.body = buffer
+            response.pointee.body_len = UInt(result.body.count)
+        }
+        return 0
+    } catch {
+        _ = String(describing: error).withCString { c2pa_error_set_last($0) }
+        return 1
+    }
+}
+
 /// An immutable, shareable configuration context for creating builders.
 ///
 /// A `C2PAContext` captures configuration — settings such as created-assertion
@@ -24,8 +188,8 @@ import Foundation
 /// ## Topics
 ///
 /// ### Creating a Context
-/// - ``init()``
-/// - ``init(settings:)``
+/// - ``init(settings:onProgress:httpResolver:)``
+/// - ``init(settings:onProgress:urlSession:)``
 ///
 /// ### Controlling Operations
 /// - ``cancel()``
@@ -42,38 +206,144 @@ import Foundation
 public final class C2PAContext {
     let ptr: UnsafeMutablePointer<C2paContext>
 
+    /// Boxes holding the callback closures the native context may invoke.
+    ///
+    /// The C layer keeps only unretained pointers to these, so they must outlive the
+    /// context. Holding them here ties their lifetime to it exactly.
+    private let callbackBoxes: [AnyObject]
+
     /// Internal initializer that adopts an already-built native context.
-    init(ptr: UnsafeMutablePointer<C2paContext>) {
+    init(ptr: UnsafeMutablePointer<C2paContext>, callbackBoxes: [AnyObject] = []) {
         self.ptr = ptr
+        self.callbackBoxes = callbackBoxes
     }
 
-    /// Creates a context with default settings.
+    /// Creates a context, optionally configured with settings and callbacks.
+    ///
+    /// The settings are cloned by the C layer, so the caller retains ownership of
+    /// `settings`. The callbacks are retained by the context and may be invoked for as
+    /// long as it is alive.
+    ///
+    /// - Parameters:
+    ///   - settings: The ``C2PASettings`` to configure this context with.
+    ///   - onProgress: Observes operation progress. Called synchronously at checkpoints;
+    ///     to stop an operation call ``cancel()`` rather than returning from here.
+    ///   - httpResolver: Resolves HTTP requests the SDK makes (remote manifests, OCSP,
+    ///     timestamps). Called synchronously and possibly from any thread, so it must be
+    ///     thread-safe. Throwing fails the request.
     ///
     /// - Throws: ``C2PAError`` if the context cannot be created.
-    public convenience init() throws {
-        self.init(ptr: try guardNotNull(c2pa_context_new()))
-    }
+    ///
+    /// ## Example
+    ///
+    /// ```swift
+    /// let context = try C2PAContext(settings: settings) { update in
+    ///     print("\(update.phase) \(update.step)/\(update.total)")
+    /// }
+    /// ```
+    public convenience init(
+        settings: C2PASettings? = nil,
+        onProgress: ((ProgressUpdate) -> Void)? = nil,
+        httpResolver: ((HTTPRequest) throws -> HTTPResponse)? = nil
+    ) throws {
+        guard settings != nil || onProgress != nil || httpResolver != nil else {
+            self.init(ptr: try guardNotNull(c2pa_context_new()))
+            return
+        }
 
-    /// Creates a context configured with the given settings.
-    ///
-    /// The settings are cloned by the C layer, so the caller retains ownership
-    /// of `settings`.
-    ///
-    /// - Parameter settings: The ``C2PASettings`` to configure this context with.
-    ///
-    /// - Throws: ``C2PAError`` if the context cannot be created.
-    public convenience init(settings: C2PASettings) throws {
         let builder = try guardNotNull(c2pa_context_builder_new())
+        var boxes: [AnyObject] = []
         do {
-            _ = try guardNonNegative(
-                Int64(c2pa_context_builder_set_settings(builder, settings.rawPtr))
-            )
+            if let settings {
+                _ = try guardNonNegative(
+                    Int64(c2pa_context_builder_set_settings(builder, settings.rawPtr)))
+            }
+
+            if let onProgress {
+                let box = ProgressCallbackBox(onProgress)
+                boxes.append(box)
+                _ = try guardNonNegative(Int64(c2pa_context_builder_set_progress_callback(
+                    builder, Unmanaged.passUnretained(box).toOpaque(), progressTrampoline)))
+            }
+
+            if let httpResolver {
+                let box = HTTPResolverBox(httpResolver)
+                boxes.append(box)
+                let resolver = try guardNotNull(c2pa_http_resolver_create(
+                    Unmanaged.passUnretained(box).toOpaque(), httpResolverTrampoline))
+                do {
+                    _ = try guardNonNegative(
+                        Int64(c2pa_context_builder_set_http_resolver(builder, resolver)))
+                } catch {
+                    // The resolver is only consumed on success, so release it ourselves.
+                    _ = c2pa_free(resolver)
+                    throw error
+                }
+            }
         } catch {
             _ = c2pa_free(builder)
             throw error
         }
+
         // c2pa_context_builder_build consumes the builder, even on failure.
-        self.init(ptr: try guardNotNull(c2pa_context_builder_build(builder)))
+        self.init(
+            ptr: try guardNotNull(c2pa_context_builder_build(builder)), callbackBoxes: boxes)
+    }
+
+    /// Creates a context whose HTTP requests are resolved by a `URLSession`.
+    ///
+    /// A separate initializer rather than a defaulted parameter, so a caller cannot pass
+    /// both this and a custom `httpResolver`.
+    ///
+    /// - Parameters:
+    ///   - settings: The ``C2PASettings`` to configure this context with.
+    ///   - onProgress: Observes operation progress. See ``init(settings:onProgress:httpResolver:)``.
+    ///   - urlSession: The session used to perform each request.
+    ///
+    /// - Throws: ``C2PAError`` if the context cannot be created.
+    public convenience init(
+        settings: C2PASettings? = nil,
+        onProgress: ((ProgressUpdate) -> Void)? = nil,
+        urlSession: URLSession
+    ) throws {
+        try self.init(
+            settings: settings,
+            onProgress: onProgress,
+            httpResolver: { request in
+                var urlRequest = URLRequest(url: request.url)
+                urlRequest.httpMethod = request.method
+                for (name, value) in request.headers {
+                    urlRequest.setValue(value, forHTTPHeaderField: name)
+                }
+                urlRequest.httpBody = request.body
+
+                // The native resolver call is synchronous, so block until the task lands.
+                // URLSession delivers on its own queue, so waiting here cannot deadlock it.
+                let resultBox = HTTPResultBox()
+                let semaphore = DispatchSemaphore(value: 0)
+                let task = urlSession.dataTask(with: urlRequest) { data, response, error in
+                    if let error {
+                        resultBox.set(.failure(
+                            C2PAError.api("HTTP resolver request failed: \(error)")))
+                    } else {
+                        resultBox.set(.success(HTTPResponse(
+                            status: (response as? HTTPURLResponse)?.statusCode ?? 0,
+                            body: data ?? Data())))
+                    }
+                    semaphore.signal()
+                }
+                task.resume()
+                semaphore.wait()
+
+                switch resultBox.get() {
+                case .success(let response):
+                    return response
+                case .failure(let error):
+                    throw error
+                case .none:
+                    throw C2PAError.api("HTTP resolver produced no response")
+                }
+            })
     }
 
     deinit { _ = c2pa_free(ptr) }

--- a/Library/Sources/C2PAContext.swift
+++ b/Library/Sources/C2PAContext.swift
@@ -56,6 +56,20 @@ public struct ProgressUpdate: Sendable {
     public let total: UInt32
 }
 
+/// What a progress observer wants the operation to do next.
+///
+/// Mirrors the native progress callback's return value, so a caller can stop the operation
+/// it is watching without reaching for ``C2PAContext/cancel()``, which stops every operation
+/// on the context.
+public enum ProgressDisposition: Sendable {
+    /// Let the operation carry on.
+    case `continue`
+
+    /// Ask the SDK to stop. It returns an error at its next safe checkpoint, so work in
+    /// flight is not abandoned mid-write.
+    case cancel
+}
+
 /// An HTTP request the SDK needs resolved (remote manifest, OCSP, or timestamp fetch).
 public struct HTTPRequest: Sendable {
     /// The request URL.
@@ -86,9 +100,9 @@ public struct HTTPResponse: Sendable {
 }
 
 private final class ProgressCallbackBox: Sendable {
-    let onProgress: @Sendable (ProgressUpdate) -> Void
+    let onProgress: @Sendable (ProgressUpdate) -> ProgressDisposition
 
-    init(_ onProgress: @escaping @Sendable (ProgressUpdate) -> Void) {
+    init(_ onProgress: @escaping @Sendable (ProgressUpdate) -> ProgressDisposition) {
         self.onProgress = onProgress
     }
 }
@@ -103,6 +117,7 @@ private final class HTTPResolverBox: Sendable {
 
 /// `ProgressCCallback` returns non-zero to continue the operation and zero to cancel.
 private let progressContinue: Int32 = 1
+private let progressCancel: Int32 = 0
 
 /// `C2paHttpResolverCallback` returns zero for success and non-zero for failure, the opposite
 /// polarity to ``progressContinue``. The two trampolines sit side by side, so both use names
@@ -110,12 +125,17 @@ private let progressContinue: Int32 = 1
 private let resolverSucceeded: Int32 = 0
 private let resolverFailed: Int32 = 1
 
-/// Observes progress and always continues; cancellation is via ``C2PAContext/cancel()``.
+/// Relays the observer's decision to the native callback, which reads zero as "stop".
+///
+/// With no observer there is nothing to ask, so the operation continues.
 private let progressTrampoline: ProgressCCallback = { context, phase, step, total in
     guard let context else { return progressContinue }
     let box = Unmanaged<ProgressCallbackBox>.fromOpaque(context).takeUnretainedValue()
-    box.onProgress(ProgressUpdate(phase: ProgressPhase(phase), step: step, total: total))
-    return progressContinue
+    let update = ProgressUpdate(phase: ProgressPhase(phase), step: step, total: total)
+    switch box.onProgress(update) {
+    case .continue: return progressContinue
+    case .cancel: return progressCancel
+    }
 }
 
 /// Resolves one request. May run on any thread, which is why the boxed closure is `@Sendable`.
@@ -207,6 +227,7 @@ private let httpResolverTrampoline: C2paHttpResolverCallback = { context, reques
 ///
 /// ### Controlling Operations
 /// - ``cancel()``
+/// - ``ProgressDisposition``
 ///
 /// ## Example
 ///
@@ -240,9 +261,10 @@ public final class C2PAContext {
     ///
     /// - Parameters:
     ///   - settings: The ``C2PASettings`` to configure this context with.
-    ///   - onProgress: Observes operation progress. Called synchronously at checkpoints,
-    ///     on whichever thread runs the operation; to stop an operation call ``cancel()``
-    ///     rather than returning from here.
+    ///   - onProgress: Observes operation progress and decides whether it continues.
+    ///     Called synchronously at checkpoints, on whichever thread runs the operation.
+    ///     Return ``ProgressDisposition/cancel`` to stop just this operation, or use
+    ///     ``cancel()`` to stop every operation on the context at once.
     ///   - httpResolver: Resolves HTTP requests the SDK makes (remote manifests, OCSP,
     ///     timestamps). Called synchronously and possibly from any thread, so it must be
     ///     thread-safe; the `@Sendable` requirement enforces that under strict
@@ -255,11 +277,12 @@ public final class C2PAContext {
     /// ```swift
     /// let context = try C2PAContext(settings: settings) { update in
     ///     print("\(update.phase) \(update.step)/\(update.total)")
+    ///     return userTappedStop ? .cancel : .continue
     /// }
     /// ```
     public convenience init(
         settings: C2PASettings? = nil,
-        onProgress: (@Sendable (ProgressUpdate) -> Void)? = nil,
+        onProgress: (@Sendable (ProgressUpdate) -> ProgressDisposition)? = nil,
         httpResolver: (@Sendable (HTTPRequest) throws -> HTTPResponse)? = nil
     ) throws {
         guard settings != nil || onProgress != nil || httpResolver != nil else {
@@ -338,7 +361,7 @@ public final class C2PAContext {
     ///   cannot be created.
     public convenience init(
         settings: C2PASettings? = nil,
-        onProgress: (@Sendable (ProgressUpdate) -> Void)? = nil,
+        onProgress: (@Sendable (ProgressUpdate) -> ProgressDisposition)? = nil,
         urlSession: URLSession
     ) throws {
         guard urlSession.delegateQueue !== OperationQueue.main else {
@@ -397,8 +420,15 @@ public final class C2PAContext {
 
     deinit { _ = c2pa_free(ptr) }
 
-    /// Requests cancellation of any in-progress signing or reading operation
-    /// running on this context.
+    /// Requests cancellation of every in-progress signing or reading operation on this
+    /// context.
+    ///
+    /// The scope is the context, not one operation. A context is shareable and one may back
+    /// several ``Builder`` and ``Reader`` instances at once, so this reaches all of them.
+    /// Give an operation its own context when it has to be cancellable on its own.
+    ///
+    /// To stop a single operation instead, return ``ProgressDisposition/cancel`` from the
+    /// progress observer passed to ``init(settings:onProgress:httpResolver:)``.
     ///
     /// - Throws: ``C2PAError`` if the cancellation request fails.
     public func cancel() throws {

--- a/Library/Sources/C2PAContext.swift
+++ b/Library/Sources/C2PAContext.swift
@@ -93,27 +93,6 @@ private final class ProgressCallbackBox: Sendable {
     }
 }
 
-/// Carries a resolver result across the `URLSession` completion boundary.
-///
-/// The completion handler is `@Sendable`, so the result cannot be written into captured
-/// local state. Mirrors the pattern already used by ``WebServiceSigner``.
-private final class HTTPResultBox: @unchecked Sendable {
-    private let lock = NSLock()
-    private var result: Result<HTTPResponse, Error>?
-
-    func set(_ value: Result<HTTPResponse, Error>) {
-        lock.lock()
-        defer { lock.unlock() }
-        result = value
-    }
-
-    func get() -> Result<HTTPResponse, Error>? {
-        lock.lock()
-        defer { lock.unlock() }
-        return result
-    }
-}
-
 private final class HTTPResolverBox: Sendable {
     let resolve: @Sendable (HTTPRequest) throws -> HTTPResponse
 
@@ -122,59 +101,94 @@ private final class HTTPResolverBox: Sendable {
     }
 }
 
+/// `ProgressCCallback` returns non-zero to continue the operation and zero to cancel.
+private let progressContinue: Int32 = 1
+
+/// `C2paHttpResolverCallback` returns zero for success and non-zero for failure, the opposite
+/// polarity to ``progressContinue``. The two trampolines sit side by side, so both use names
+/// rather than bare literals: `1` means "carry on" in one and "gave up" in the other.
+private let resolverSucceeded: Int32 = 0
+private let resolverFailed: Int32 = 1
+
 /// Observes progress and always continues; cancellation is via ``C2PAContext/cancel()``.
 private let progressTrampoline: ProgressCCallback = { context, phase, step, total in
-    guard let context else { return 1 }
+    guard let context else { return progressContinue }
     let box = Unmanaged<ProgressCallbackBox>.fromOpaque(context).takeUnretainedValue()
     box.onProgress(ProgressUpdate(phase: ProgressPhase(phase), step: step, total: total))
-    return 1
+    return progressContinue
 }
 
 /// Resolves one request. May run on any thread, which is why the boxed closure is `@Sendable`.
+///
+/// Returning non-zero signals failure, and the contract requires setting the error message
+/// first: the native side reads it on this same thread as soon as the callback returns.
 private let httpResolverTrampoline: C2paHttpResolverCallback = { context, request, response in
-    guard let context, let request, let response else { return 1 }
+    guard let context, let request, let response else {
+        setLastC2PAError("NullParameter: HTTP resolver received a null pointer")
+        return resolverFailed
+    }
     let box = Unmanaged<HTTPResolverBox>.fromOpaque(context).takeUnretainedValue()
     let incoming = request.pointee
 
     guard let urlPtr = incoming.url, let url = URL(string: String(cString: urlPtr)) else {
-        _ = "Invalid request URL".withCString { c2pa_error_set_last($0) }
-        return 1
+        setLastC2PAError("Other: invalid HTTP request URL")
+        return resolverFailed
     }
 
-    let method = incoming.method.map { String(cString: $0) } ?? "GET"
+    // The native side always sends a method, so this refuses rather than guessing: a silent
+    // fallback to GET would turn a POST (OCSP, timestamping) into a request the server
+    // rejects, surfacing far from the cause.
+    guard let methodPtr = incoming.method else {
+        setLastC2PAError("NullParameter: HTTP request has no method")
+        return resolverFailed
+    }
+    let method = String(cString: methodPtr)
     var headers: [String: String] = [:]
     if let rawHeaders = incoming.headers {
         for line in String(cString: rawHeaders).split(separator: "\n") {
             guard let separator = line.firstIndex(of: ":") else { continue }
-            let name = String(line[..<separator]).trimmingCharacters(in: .whitespaces)
-            let value = String(line[line.index(after: separator)...]).trimmingCharacters(in: .whitespaces)
+            // Newlines are in the trim set too: the C layer documents "\n"-delimited headers,
+            // but CRLF would otherwise leave a trailing "\r" on every value.
+            let name = String(line[..<separator])
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            let value = String(line[line.index(after: separator)...])
+                .trimmingCharacters(in: .whitespacesAndNewlines)
             if !name.isEmpty { headers[name] = value }
         }
     }
-    let body: Data? = (incoming.body != nil && incoming.body_len > 0)
-        ? Data(bytes: incoming.body!, count: Int(incoming.body_len)) : nil
+    let body: Data? = incoming.body.flatMap { bytes in
+        incoming.body_len > 0 ? Data(bytes: bytes, count: Int(incoming.body_len)) : nil
+    }
 
     do {
         let result = try box.resolve(
             HTTPRequest(url: url, method: method, headers: headers, body: body))
-        response.pointee.status = Int32(result.status)
+        // Int32(_:) would trap here, killing the process from inside a C callback where no
+        // Swift frame can catch it. The status is caller-supplied, so refuse it instead.
+        guard let status = Int32(exactly: result.status) else {
+            setLastC2PAError("Other: HTTP response status \(result.status) is out of range")
+            return resolverFailed
+        }
+        response.pointee.status = status
         if result.body.isEmpty {
+            // Both fields must move together. Rust skips its free when body_len is zero, so a
+            // non-null pointer paired with a zero length would leak the allocation.
             response.pointee.body = nil
             response.pointee.body_len = 0
         } else {
             // Rust takes ownership of this allocation and frees it.
             guard let buffer = malloc(result.body.count)?.assumingMemoryBound(to: UInt8.self) else {
-                _ = "Failed to allocate response body".withCString { c2pa_error_set_last($0) }
-                return 1
+                setLastC2PAError("Other: failed to allocate the HTTP response body")
+                return resolverFailed
             }
             result.body.copyBytes(to: buffer, count: result.body.count)
             response.pointee.body = buffer
             response.pointee.body_len = UInt(result.body.count)
         }
-        return 0
+        return resolverSucceeded
     } catch {
-        _ = String(describing: error).withCString { c2pa_error_set_last($0) }
-        return 1
+        setLastC2PAError("Other: \(error.localizedDescription)")
+        return resolverFailed
     }
 }
 
@@ -277,7 +291,11 @@ public final class C2PAContext {
                     _ = try guardNonNegative(
                         Int64(c2pa_context_builder_set_http_resolver(builder, resolver)))
                 } catch {
-                    // The resolver is only consumed on success, so release it ourselves.
+                    // Ownership passes only once the native call's own pointer checks have
+                    // passed, so a failure here means the resolver was not taken and is ours
+                    // to release. Note the header states consumption unconditionally, which is
+                    // stricter than the implementation: verified against c2pa-c-ffi-v0.90.0,
+                    // and worth re-checking whenever C2PA_VERSION moves.
                     _ = c2pa_free(resolver)
                     throw error
                 }
@@ -303,18 +321,30 @@ public final class C2PAContext {
     /// the main thread) will deadlock if the operation runs on the main thread. Pass a
     /// session whose delegate queue is a background queue.
     ///
+    /// A session delivering on `OperationQueue.main` is rejected here rather than left to
+    /// hang at first use. A delegate that merely hops to the main thread itself cannot be
+    /// detected, so the caller still owns that half of the requirement.
+    ///
     /// - Parameters:
     ///   - settings: The ``C2PASettings`` to configure this context with.
     ///   - onProgress: Observes operation progress. See ``init(settings:onProgress:httpResolver:)``.
     ///   - urlSession: The session used to perform each request. Must not deliver its
-    ///     callbacks on the main queue.
+    ///     callbacks on the main queue, and must stay valid for as long as this context
+    ///     does: an invalidated session hands back tasks whose completion handler never
+    ///     runs, which would block a resolving thread indefinitely. Request timeouts are
+    ///     taken from the session's own configuration; nothing is imposed on top.
     ///
-    /// - Throws: ``C2PAError`` if the context cannot be created.
+    /// - Throws: ``C2PAError`` if `urlSession` delivers on the main queue, or if the context
+    ///   cannot be created.
     public convenience init(
         settings: C2PASettings? = nil,
         onProgress: (@Sendable (ProgressUpdate) -> Void)? = nil,
         urlSession: URLSession
     ) throws {
+        guard urlSession.delegateQueue !== OperationQueue.main else {
+            throw C2PAError.api(
+                "URLSession delivers on the main queue, which would deadlock the resolver")
+        }
         try self.init(
             settings: settings,
             onProgress: onProgress,
@@ -328,30 +358,40 @@ public final class C2PAContext {
 
                 // The native resolver call is synchronous, so block until the task lands.
                 // URLSession delivers on its own queue, so waiting here cannot deadlock it.
-                let resultBox = HTTPResultBox()
+                //
+                // The wait is deliberately unbounded. Timeout policy belongs to the caller's
+                // URLSessionConfiguration, which already carries both knobs, and this has no
+                // basis for overriding them: timeoutIntervalForRequest is an idle timeout, so
+                // a slow but progressing transfer legitimately outlives it.
+                //
+                // The signal/wait pair orders every access to `result`, which is what makes
+                // the unchecked capture below sound.
                 let semaphore = DispatchSemaphore(value: 0)
+                nonisolated(unsafe) var result: Result<HTTPResponse, Error>?
                 let task = urlSession.dataTask(with: urlRequest) { data, response, error in
                     if let error {
-                        resultBox.set(.failure(
-                            C2PAError.api("HTTP resolver request failed: \(error)")))
+                        result = .failure(
+                            C2PAError.api("HTTP resolver request failed: \(error)"))
+                    } else if let http = response as? HTTPURLResponse {
+                        result = .success(HTTPResponse(
+                            status: http.statusCode, body: data ?? Data()))
                     } else {
-                        resultBox.set(.success(HTTPResponse(
-                            status: (response as? HTTPURLResponse)?.statusCode ?? 0,
-                            body: data ?? Data())))
+                        // Every request the SDK makes here is HTTP. Reporting status 0 for
+                        // anything else would look like a successful fetch of nothing.
+                        result = .failure(C2PAError.api(
+                            "HTTP resolver got a non-HTTP response for \(request.url)"))
                     }
                     semaphore.signal()
                 }
                 task.resume()
                 semaphore.wait()
 
-                switch resultBox.get() {
-                case .success(let response):
-                    return response
-                case .failure(let error):
-                    throw error
-                case .none:
+                // Unreachable: the semaphore is only signalled after `result` is set. Present
+                // because the compiler cannot see that.
+                guard let result else {
                     throw C2PAError.api("HTTP resolver produced no response")
                 }
+                return try result.get()
             })
     }
 

--- a/Library/Sources/C2PAContext.swift
+++ b/Library/Sources/C2PAContext.swift
@@ -85,10 +85,10 @@ public struct HTTPResponse: Sendable {
     }
 }
 
-private final class ProgressCallbackBox {
-    let onProgress: (ProgressUpdate) -> Void
+private final class ProgressCallbackBox: Sendable {
+    let onProgress: @Sendable (ProgressUpdate) -> Void
 
-    init(_ onProgress: @escaping (ProgressUpdate) -> Void) {
+    init(_ onProgress: @escaping @Sendable (ProgressUpdate) -> Void) {
         self.onProgress = onProgress
     }
 }
@@ -114,10 +114,10 @@ private final class HTTPResultBox: @unchecked Sendable {
     }
 }
 
-private final class HTTPResolverBox {
-    let resolve: (HTTPRequest) throws -> HTTPResponse
+private final class HTTPResolverBox: Sendable {
+    let resolve: @Sendable (HTTPRequest) throws -> HTTPResponse
 
-    init(_ resolve: @escaping (HTTPRequest) throws -> HTTPResponse) {
+    init(_ resolve: @escaping @Sendable (HTTPRequest) throws -> HTTPResponse) {
         self.resolve = resolve
     }
 }
@@ -130,7 +130,7 @@ private let progressTrampoline: ProgressCCallback = { context, phase, step, tota
     return 1
 }
 
-/// Resolves one request. May run on any thread, so the boxed closure must be thread-safe.
+/// Resolves one request. May run on any thread, which is why the boxed closure is `@Sendable`.
 private let httpResolverTrampoline: C2paHttpResolverCallback = { context, request, response in
     guard let context, let request, let response else { return 1 }
     let box = Unmanaged<HTTPResolverBox>.fromOpaque(context).takeUnretainedValue()
@@ -226,11 +226,13 @@ public final class C2PAContext {
     ///
     /// - Parameters:
     ///   - settings: The ``C2PASettings`` to configure this context with.
-    ///   - onProgress: Observes operation progress. Called synchronously at checkpoints;
-    ///     to stop an operation call ``cancel()`` rather than returning from here.
+    ///   - onProgress: Observes operation progress. Called synchronously at checkpoints,
+    ///     on whichever thread runs the operation; to stop an operation call ``cancel()``
+    ///     rather than returning from here.
     ///   - httpResolver: Resolves HTTP requests the SDK makes (remote manifests, OCSP,
     ///     timestamps). Called synchronously and possibly from any thread, so it must be
-    ///     thread-safe. Throwing fails the request.
+    ///     thread-safe; the `@Sendable` requirement enforces that under strict
+    ///     concurrency checking. Throwing fails the request.
     ///
     /// - Throws: ``C2PAError`` if the context cannot be created.
     ///
@@ -243,8 +245,8 @@ public final class C2PAContext {
     /// ```
     public convenience init(
         settings: C2PASettings? = nil,
-        onProgress: ((ProgressUpdate) -> Void)? = nil,
-        httpResolver: ((HTTPRequest) throws -> HTTPResponse)? = nil
+        onProgress: (@Sendable (ProgressUpdate) -> Void)? = nil,
+        httpResolver: (@Sendable (HTTPRequest) throws -> HTTPResponse)? = nil
     ) throws {
         guard settings != nil || onProgress != nil || httpResolver != nil else {
             self.init(ptr: try guardNotNull(c2pa_context_new()))
@@ -295,15 +297,22 @@ public final class C2PAContext {
     /// A separate initializer rather than a defaulted parameter, so a caller cannot pass
     /// both this and a custom `httpResolver`.
     ///
+    /// Each request blocks the calling thread until the session's completion handler
+    /// fires. That cannot deadlock against a session using the default delegate queue,
+    /// but a session created with `delegateQueue: .main` (or whose delegate does work on
+    /// the main thread) will deadlock if the operation runs on the main thread. Pass a
+    /// session whose delegate queue is a background queue.
+    ///
     /// - Parameters:
     ///   - settings: The ``C2PASettings`` to configure this context with.
     ///   - onProgress: Observes operation progress. See ``init(settings:onProgress:httpResolver:)``.
-    ///   - urlSession: The session used to perform each request.
+    ///   - urlSession: The session used to perform each request. Must not deliver its
+    ///     callbacks on the main queue.
     ///
     /// - Throws: ``C2PAError`` if the context cannot be created.
     public convenience init(
         settings: C2PASettings? = nil,
-        onProgress: ((ProgressUpdate) -> Void)? = nil,
+        onProgress: (@Sendable (ProgressUpdate) -> Void)? = nil,
         urlSession: URLSession
     ) throws {
         try self.init(

--- a/Library/Sources/Helpers.swift
+++ b/Library/Sources/Helpers.swift
@@ -30,6 +30,16 @@ func lastC2PAError() -> String {
     return String(cString: p)
 }
 
+/// Records a failure message for the native layer to read back.
+///
+/// The C layer parses `"ErrorType: message"`, splitting on the first `": "` only, and maps
+/// an unrecognised type to `Other`. Always pass a valid type prefix: an unprefixed message
+/// that happens to contain `": "` would have its first segment read as a type tag.
+@inline(__always)
+func setLastC2PAError(_ message: String) {
+    _ = message.withCString { c2pa_error_set_last($0) }
+}
+
 @inline(__always)
 func guardNotNull<T>(_ p: UnsafeMutablePointer<T>?) throws -> UnsafeMutablePointer<T> {
     if let p { return p }

--- a/Library/Tests/LibraryTestRunner.swift
+++ b/Library/Tests/LibraryTestRunner.swift
@@ -1033,6 +1033,16 @@ final class ContextTests: XCTestCase {
         XCTAssertTrue(result.passed, result.message)
     }
 
+    func testHTTPResolverRemoteManifestFetch() throws {
+        let result = tests.testHTTPResolverRemoteManifestFetch()
+        XCTAssertTrue(result.passed, result.message)
+    }
+
+    func testHTTPResolverErrorFailsRead() throws {
+        let result = tests.testHTTPResolverErrorFailsRead()
+        XCTAssertTrue(result.passed, result.message)
+    }
+
     func testContextWithSettingsAndCallbacks() throws {
         let result = tests.testContextWithSettingsAndCallbacks()
         XCTAssertTrue(result.passed, result.message)

--- a/Library/Tests/LibraryTestRunner.swift
+++ b/Library/Tests/LibraryTestRunner.swift
@@ -1023,6 +1023,11 @@ final class ContextTests: XCTestCase {
         XCTAssertTrue(result.passed, result.message)
     }
 
+    func testProgressCallbackCancelsOperation() throws {
+        let result = tests.testProgressCallbackCancelsOperation()
+        XCTAssertTrue(result.passed, result.message)
+    }
+
     func testHTTPResolver() throws {
         let result = tests.testHTTPResolver()
         XCTAssertTrue(result.passed, result.message)

--- a/Library/Tests/LibraryTestRunner.swift
+++ b/Library/Tests/LibraryTestRunner.swift
@@ -1043,6 +1043,26 @@ final class ContextTests: XCTestCase {
         XCTAssertTrue(result.passed, result.message)
     }
 
+    func testHTTPResolverRejectsOutOfRangeStatus() throws {
+        let result = tests.testHTTPResolverRejectsOutOfRangeStatus()
+        XCTAssertTrue(result.passed, result.message)
+    }
+
+    func testURLSessionResolverRejectsMainQueueSession() throws {
+        let result = tests.testURLSessionResolverRejectsMainQueueSession()
+        XCTAssertTrue(result.passed, result.message)
+    }
+
+    func testURLSessionResolverFetchesRemoteManifest() throws {
+        let result = tests.testURLSessionResolverFetchesRemoteManifest()
+        XCTAssertTrue(result.passed, result.message)
+    }
+
+    func testHTTPResolverEmptyResponseBody() throws {
+        let result = tests.testHTTPResolverEmptyResponseBody()
+        XCTAssertTrue(result.passed, result.message)
+    }
+
     func testContextWithSettingsAndCallbacks() throws {
         let result = tests.testContextWithSettingsAndCallbacks()
         XCTAssertTrue(result.passed, result.message)

--- a/Library/Tests/LibraryTestRunner.swift
+++ b/Library/Tests/LibraryTestRunner.swift
@@ -1017,6 +1017,26 @@ final class ContextTests: XCTestCase {
         let result = tests.testSettingsFlowRoundtrip()
         XCTAssertTrue(result.passed, result.message)
     }
+
+    func testProgressCallback() throws {
+        let result = tests.testProgressCallback()
+        XCTAssertTrue(result.passed, result.message)
+    }
+
+    func testHTTPResolver() throws {
+        let result = tests.testHTTPResolver()
+        XCTAssertTrue(result.passed, result.message)
+    }
+
+    func testURLSessionHTTPResolver() throws {
+        let result = tests.testURLSessionHTTPResolver()
+        XCTAssertTrue(result.passed, result.message)
+    }
+
+    func testContextWithSettingsAndCallbacks() throws {
+        let result = tests.testContextWithSettingsAndCallbacks()
+        XCTAssertTrue(result.passed, result.message)
+    }
 }
 
 // MARK: - Settings Definition Tests

--- a/TestShared/Sources/ContextTests.swift
+++ b/TestShared/Sources/ContextTests.swift
@@ -115,13 +115,125 @@ public final class ContextTests: TestImplementation {
         }
     }
 
+    public func testProgressCallback() -> TestResult {
+        let tempDir = FileManager.default.temporaryDirectory
+        let sourceURL = tempDir.appendingPathComponent("prog_src_\(UUID().uuidString).jpg")
+        let destURL = tempDir.appendingPathComponent("prog_dst_\(UUID().uuidString).jpg")
+        defer {
+            try? FileManager.default.removeItem(at: sourceURL)
+            try? FileManager.default.removeItem(at: destURL)
+        }
+
+        // The callback fires synchronously on the signing thread, but a plain array would
+        // still be shared mutable state as far as the compiler is concerned.
+        final class Recorder: @unchecked Sendable {
+            private let lock = NSLock()
+            private var phases: [ProgressPhase] = []
+            func record(_ phase: ProgressPhase) {
+                lock.lock()
+                defer { lock.unlock() }
+                phases.append(phase)
+            }
+            var observed: [ProgressPhase] {
+                lock.lock()
+                defer { lock.unlock() }
+                return phases
+            }
+        }
+        let recorder = Recorder()
+
+        do {
+            guard let imageData = TestUtilities.loadPexelsTestImage() else {
+                return .failure("Progress Callback", "Could not load test image")
+            }
+            try imageData.write(to: sourceURL)
+
+            let context = try C2PAContext(onProgress: { recorder.record($0.phase) })
+            let builder = try Builder(
+                context: context, manifestJSON: TestUtilities.createTestManifestJSON())
+            _ = try builder.sign(
+                format: "image/jpeg",
+                source: try Stream(readFrom: sourceURL),
+                destination: try Stream(writeTo: destURL),
+                signer: try TestUtilities.createTestSigner())
+
+            let observed = recorder.observed
+            guard !observed.isEmpty else {
+                return .success(
+                    "Progress Callback", "[WARN] no progress updates observed (environment-dependent)")
+            }
+            guard !observed.contains(.unknown) else {
+                return .failure(
+                    "Progress Callback",
+                    "a phase did not map to a known case, so the native enum has drifted")
+            }
+            return .success("Progress Callback", "[PASS] observed \(observed.count) updates")
+        } catch let error as C2PAError {
+            return .success("Progress Callback", "[WARN] progress path callable (error: \(error))")
+        } catch {
+            return .failure("Progress Callback", "Error: \(error)")
+        }
+    }
+
+    public func testHTTPResolver() -> TestResult {
+        do {
+            // Installing the resolver is what is under test; whether the SDK makes a
+            // request during this operation is environment-dependent.
+            let context = try C2PAContext(httpResolver: { request in
+                HTTPResponse(status: 200, body: Data("\(request.method) \(request.url)".utf8))
+            })
+            _ = try Builder(context: context, manifestJSON: TestUtilities.createTestManifestJSON())
+            return .success("HTTP Resolver", "[PASS] custom HTTP resolver installed")
+        } catch let error as C2PAError {
+            return .success("HTTP Resolver", "[WARN] resolver path callable (error: \(error))")
+        } catch {
+            return .failure("HTTP Resolver", "Error: \(error)")
+        }
+    }
+
+    public func testURLSessionHTTPResolver() -> TestResult {
+        do {
+            let context = try C2PAContext(urlSession: .shared)
+            _ = try Builder(context: context, manifestJSON: TestUtilities.createTestManifestJSON())
+            return .success("URLSession HTTP Resolver", "[PASS] URLSession resolver installed")
+        } catch let error as C2PAError {
+            return .success("URLSession HTTP Resolver", "[WARN] resolver callable (error: \(error))")
+        } catch {
+            return .failure("URLSession HTTP Resolver", "Error: \(error)")
+        }
+    }
+
+    public func testContextWithSettingsAndCallbacks() -> TestResult {
+        // All three configuration inputs at once: each is applied to the same transient
+        // native builder, so a mistake in that sequence shows up here.
+        do {
+            let settings = try C2PASettings(json: "{\"version\": 1}")
+            let context = try C2PAContext(
+                settings: settings,
+                onProgress: { _ in },
+                httpResolver: { _ in HTTPResponse(status: 204, body: Data()) })
+            try context.cancel()
+            return .success(
+                "Context Settings And Callbacks", "[PASS] settings and both callbacks applied")
+        } catch let error as C2PAError {
+            return .success(
+                "Context Settings And Callbacks", "[WARN] path callable (error: \(error))")
+        } catch {
+            return .failure("Context Settings And Callbacks", "Error: \(error)")
+        }
+    }
+
     public func runAllTests() async -> [TestResult] {
         [
             testContextDefaultCreation(),
             testContextFromSettings(),
             testContextCancel(),
             testBuilderFromContext(),
-            testSettingsFlowRoundtrip()
+            testSettingsFlowRoundtrip(),
+            testProgressCallback(),
+            testHTTPResolver(),
+            testURLSessionHTTPResolver(),
+            testContextWithSettingsAndCallbacks()
         ]
     }
 }

--- a/TestShared/Sources/ContextTests.swift
+++ b/TestShared/Sources/ContextTests.swift
@@ -214,7 +214,10 @@ public final class ContextTests: TestImplementation {
             }
             try imageData.write(to: sourceURL)
 
-            let context = try C2PAContext(onProgress: { recorder.record($0.phase) })
+            let context = try C2PAContext(onProgress: {
+                recorder.record($0.phase)
+                return .continue
+            })
             let builder = try Builder(
                 context: context, manifestJSON: TestUtilities.createTestManifestJSON())
             _ = try builder.sign(
@@ -239,6 +242,52 @@ public final class ContextTests: TestImplementation {
             return .success("Progress Callback", "[PASS] observed \(observed.count) updates")
         } catch {
             return .failure("Progress Callback", "Error: \(error)")
+        }
+    }
+
+    public func testProgressCallbackCancelsOperation() -> TestResult {
+        let name = "Progress Callback Cancels Operation"
+        let tempDir = FileManager.default.temporaryDirectory
+        let sourceURL = tempDir.appendingPathComponent("cancel_src_\(UUID().uuidString).jpg")
+        let destURL = tempDir.appendingPathComponent("cancel_dst_\(UUID().uuidString).jpg")
+        defer {
+            try? FileManager.default.removeItem(at: sourceURL)
+            try? FileManager.default.removeItem(at: destURL)
+        }
+
+        let recorder = CallbackRecorder<ProgressPhase>()
+
+        do {
+            guard let imageData = TestUtilities.loadPexelsTestImage() else {
+                return .failure(name, "Could not load test image")
+            }
+            try imageData.write(to: sourceURL)
+
+            // Cancels at the first checkpoint, which is what distinguishes this from
+            // context-wide cancel(): only this operation is asked to stop.
+            let context = try C2PAContext(onProgress: {
+                recorder.record($0.phase)
+                return .cancel
+            })
+            let builder = try Builder(
+                context: context, manifestJSON: TestUtilities.createTestManifestJSON())
+
+            do {
+                _ = try builder.sign(
+                    format: "image/jpeg",
+                    source: try Stream(readFrom: sourceURL),
+                    destination: try Stream(writeTo: destURL),
+                    signer: try TestUtilities.createTestSigner())
+                return .failure(name, "sign completed although the observer asked to cancel")
+            } catch is C2PAError {
+                guard !recorder.recorded.isEmpty else {
+                    return .failure(name, "sign failed before any progress was reported")
+                }
+                return .success(
+                    name, "[PASS] cancelled after \(recorder.recorded.count) update(s)")
+            }
+        } catch {
+            return .failure(name, "Error: \(error)")
         }
     }
 
@@ -273,7 +322,7 @@ public final class ContextTests: TestImplementation {
             let settings = try C2PASettings(json: "{\"version\": 1}")
             let context = try C2PAContext(
                 settings: settings,
-                onProgress: { _ in },
+                onProgress: { _ in .continue },
                 httpResolver: { _ in HTTPResponse(status: 204, body: Data()) })
             try context.cancel()
             return .success(
@@ -525,6 +574,7 @@ public final class ContextTests: TestImplementation {
             testBuilderFromContext(),
             testSettingsFlowRoundtrip(),
             testProgressCallback(),
+            testProgressCallbackCancelsOperation(),
             testHTTPResolver(),
             testURLSessionHTTPResolver(),
             testContextWithSettingsAndCallbacks(),

--- a/TestShared/Sources/ContextTests.swift
+++ b/TestShared/Sources/ContextTests.swift
@@ -11,6 +11,27 @@
 import C2PA
 import Foundation
 
+/// Collects values delivered from native callbacks.
+///
+/// Callbacks fire synchronously on the thread running the operation, but a plain array
+/// would still be shared mutable state as far as the compiler is concerned.
+private final class CallbackRecorder<Value>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var values: [Value] = []
+
+    func record(_ value: Value) {
+        lock.lock()
+        defer { lock.unlock() }
+        values.append(value)
+    }
+
+    var recorded: [Value] {
+        lock.lock()
+        defer { lock.unlock() }
+        return values
+    }
+}
+
 // Context API tests - pure Swift implementation
 public final class ContextTests: TestImplementation {
 
@@ -124,23 +145,7 @@ public final class ContextTests: TestImplementation {
             try? FileManager.default.removeItem(at: destURL)
         }
 
-        // The callback fires synchronously on the signing thread, but a plain array would
-        // still be shared mutable state as far as the compiler is concerned.
-        final class Recorder: @unchecked Sendable {
-            private let lock = NSLock()
-            private var phases: [ProgressPhase] = []
-            func record(_ phase: ProgressPhase) {
-                lock.lock()
-                defer { lock.unlock() }
-                phases.append(phase)
-            }
-            var observed: [ProgressPhase] {
-                lock.lock()
-                defer { lock.unlock() }
-                return phases
-            }
-        }
-        let recorder = Recorder()
+        let recorder = CallbackRecorder<ProgressPhase>()
 
         do {
             guard let imageData = TestUtilities.loadPexelsTestImage() else {
@@ -157,35 +162,34 @@ public final class ContextTests: TestImplementation {
                 destination: try Stream(writeTo: destURL),
                 signer: try TestUtilities.createTestSigner())
 
-            let observed = recorder.observed
-            guard !observed.isEmpty else {
-                return .success(
-                    "Progress Callback", "[WARN] no progress updates observed (environment-dependent)")
-            }
+            let observed = recorder.recorded
             guard !observed.contains(.unknown) else {
                 return .failure(
                     "Progress Callback",
                     "a phase did not map to a known case, so the native enum has drifted")
             }
+            // A local sign always hashes the asset and signs the claim, so at least one of
+            // those phases must be reported if the callback is wired through at all.
+            guard observed.contains(.hashing) || observed.contains(.signing) else {
+                return .failure(
+                    "Progress Callback",
+                    "expected a hashing or signing phase, observed \(observed)")
+            }
             return .success("Progress Callback", "[PASS] observed \(observed.count) updates")
-        } catch let error as C2PAError {
-            return .success("Progress Callback", "[WARN] progress path callable (error: \(error))")
         } catch {
             return .failure("Progress Callback", "Error: \(error)")
         }
     }
 
     public func testHTTPResolver() -> TestResult {
+        // Installing a resolver on a fresh context is deterministic, so any error here is
+        // a failure. Driving the resolver is covered by testHTTPResolverRemoteManifestFetch.
         do {
-            // Installing the resolver is what is under test; whether the SDK makes a
-            // request during this operation is environment-dependent.
             let context = try C2PAContext(httpResolver: { request in
                 HTTPResponse(status: 200, body: Data("\(request.method) \(request.url)".utf8))
             })
             _ = try Builder(context: context, manifestJSON: TestUtilities.createTestManifestJSON())
             return .success("HTTP Resolver", "[PASS] custom HTTP resolver installed")
-        } catch let error as C2PAError {
-            return .success("HTTP Resolver", "[WARN] resolver path callable (error: \(error))")
         } catch {
             return .failure("HTTP Resolver", "Error: \(error)")
         }
@@ -196,8 +200,6 @@ public final class ContextTests: TestImplementation {
             let context = try C2PAContext(urlSession: .shared)
             _ = try Builder(context: context, manifestJSON: TestUtilities.createTestManifestJSON())
             return .success("URLSession HTTP Resolver", "[PASS] URLSession resolver installed")
-        } catch let error as C2PAError {
-            return .success("URLSession HTTP Resolver", "[WARN] resolver callable (error: \(error))")
         } catch {
             return .failure("URLSession HTTP Resolver", "Error: \(error)")
         }
@@ -215,11 +217,121 @@ public final class ContextTests: TestImplementation {
             try context.cancel()
             return .success(
                 "Context Settings And Callbacks", "[PASS] settings and both callbacks applied")
-        } catch let error as C2PAError {
-            return .success(
-                "Context Settings And Callbacks", "[WARN] path callable (error: \(error))")
         } catch {
             return .failure("Context Settings And Callbacks", "Error: \(error)")
+        }
+    }
+
+    /// The URL a remotely hosted manifest is declared at in the resolver tests.
+    private static let remoteManifestURL = URL(string: "https://example.com/manifests/test.c2pa")!
+
+    /// Signs the test image with the manifest hosted at ``remoteManifestURL`` rather than
+    /// embedded, so reading the result forces a fetch through the context's resolver.
+    ///
+    /// - Returns: The signed asset and the manifest store bytes a resolver should serve.
+    private func signWithRemoteManifest() throws -> (asset: Data, manifest: Data) {
+        let tempDir = FileManager.default.temporaryDirectory
+        let sourceURL = tempDir.appendingPathComponent("remote_src_\(UUID().uuidString).jpg")
+        let destURL = tempDir.appendingPathComponent("remote_dst_\(UUID().uuidString).jpg")
+        defer {
+            try? FileManager.default.removeItem(at: sourceURL)
+            try? FileManager.default.removeItem(at: destURL)
+        }
+
+        guard let imageData = TestUtilities.loadPexelsTestImage() else {
+            throw C2PAError.api("Could not load test image")
+        }
+        try imageData.write(to: sourceURL)
+
+        let builder = try Builder(manifestJSON: TestUtilities.createTestManifestJSON())
+        builder.setNoEmbed()
+        try builder.setRemote(url: Self.remoteManifestURL)
+        let manifest = try builder.sign(
+            format: "image/jpeg",
+            source: try Stream(readFrom: sourceURL),
+            destination: try Stream(writeTo: destURL),
+            signer: try TestUtilities.createTestSigner())
+        return (try Data(contentsOf: destURL), manifest)
+    }
+
+    /// A context whose settings force remote manifests to be fetched, so the resolver is
+    /// guaranteed to be consulted rather than the read short-circuiting on the URL.
+    private func remoteFetchContext(
+        httpResolver: @escaping @Sendable (HTTPRequest) throws -> HTTPResponse
+    ) throws -> C2PAContext {
+        let settings = try C2PASettings(
+            json: "{\"version\": 1, \"verify\": {\"remote_manifest_fetch\": true}}")
+        return try C2PAContext(settings: settings, httpResolver: httpResolver)
+    }
+
+    public func testHTTPResolverRemoteManifestFetch() -> TestResult {
+        let name = "HTTP Resolver Remote Manifest Fetch"
+        do {
+            let (asset, manifest) = try signWithRemoteManifest()
+            let requests = CallbackRecorder<HTTPRequest>()
+            let context = try remoteFetchContext { request in
+                requests.record(request)
+                return HTTPResponse(status: 200, body: manifest)
+            }
+
+            let reader = try Reader(context: context, format: "image/jpeg", stream: try Stream(data: asset))
+            let json = try reader.json()
+
+            let seen = requests.recorded
+            guard seen.count == 1, let request = seen.first else {
+                return .failure(name, "expected exactly one resolver call, got \(seen.count)")
+            }
+            guard request.url == Self.remoteManifestURL else {
+                return .failure(name, "resolver called with \(request.url), expected \(Self.remoteManifestURL)")
+            }
+            guard request.method == "GET" else {
+                return .failure(name, "resolver called with method \(request.method), expected GET")
+            }
+            guard request.body == nil else {
+                return .failure(name, "GET request unexpectedly carried a body")
+            }
+            guard reader.remote() == Self.remoteManifestURL else {
+                return .failure(name, "reader.remote() was \(String(describing: reader.remote()))")
+            }
+            // The reader renders the manifest store it fetched, so the active manifest must
+            // be present and carry the assertion we signed with.
+            guard let store = try JSONSerialization.jsonObject(with: Data(json.utf8)) as? [String: Any],
+                  let active = store["active_manifest"] as? String,
+                  let manifests = store["manifests"] as? [String: Any],
+                  let manifest = manifests[active] as? [String: Any],
+                  let assertions = manifest["assertions"] as? [[String: Any]],
+                  assertions.contains(where: { $0["label"] as? String == "c2pa.test" })
+            else {
+                return .failure(name, "fetched manifest did not round-trip: \(json.prefix(300))")
+            }
+            return .success(name, "[PASS] resolver served \(manifest.count) byte manifest for \(request.url)")
+        } catch {
+            return .failure(name, "Error: \(error)")
+        }
+    }
+
+    public func testHTTPResolverErrorFailsRead() -> TestResult {
+        let name = "HTTP Resolver Error Fails Read"
+        struct ResolverRefused: Error {}
+        do {
+            let (asset, _) = try signWithRemoteManifest()
+            let requests = CallbackRecorder<HTTPRequest>()
+            let context = try remoteFetchContext { request in
+                requests.record(request)
+                throw ResolverRefused()
+            }
+
+            do {
+                _ = try Reader(context: context, format: "image/jpeg", stream: try Stream(data: asset))
+                return .failure(name, "read succeeded although the resolver threw")
+            } catch is C2PAError {
+                guard requests.recorded.count == 1 else {
+                    return .failure(name, "resolver was called \(requests.recorded.count) times, expected 1")
+                }
+                return .success(name, "[PASS] resolver error surfaced as C2PAError from the read")
+            }
+        } catch {
+            return .failure(name, "Error: \(error)")
         }
     }
 
@@ -233,7 +345,9 @@ public final class ContextTests: TestImplementation {
             testProgressCallback(),
             testHTTPResolver(),
             testURLSessionHTTPResolver(),
-            testContextWithSettingsAndCallbacks()
+            testContextWithSettingsAndCallbacks(),
+            testHTTPResolverRemoteManifestFetch(),
+            testHTTPResolverErrorFailsRead()
         ]
     }
 }

--- a/TestShared/Sources/ContextTests.swift
+++ b/TestShared/Sources/ContextTests.swift
@@ -32,6 +32,67 @@ private final class CallbackRecorder<Value>: @unchecked Sendable {
     }
 }
 
+/// Serves canned HTTP responses inside a `URLSession` without touching the network, so the
+/// `URLSession`-backed resolver can be exercised end to end. Only sessions that list this in
+/// `URLSessionConfiguration.protocolClasses` are affected.
+private final class StubURLProtocol: URLProtocol {
+    fileprivate final class State: @unchecked Sendable {
+        private let lock = NSLock()
+        private var status = 200
+        private var body = Data()
+        private var requests: [URLRequest] = []
+
+        func stub(status: Int, body: Data) {
+            lock.lock()
+            defer { lock.unlock() }
+            self.status = status
+            self.body = body
+            requests = []
+        }
+
+        func response() -> (status: Int, body: Data) {
+            lock.lock()
+            defer { lock.unlock() }
+            return (status, body)
+        }
+
+        func record(_ request: URLRequest) {
+            lock.lock()
+            defer { lock.unlock() }
+            requests.append(request)
+        }
+
+        var recorded: [URLRequest] {
+            lock.lock()
+            defer { lock.unlock() }
+            return requests
+        }
+    }
+
+    fileprivate static let state = State()
+
+    override static func canInit(with request: URLRequest) -> Bool { true }
+
+    override static func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        Self.state.record(request)
+        let stub = Self.state.response()
+        guard let url = request.url,
+              let response = HTTPURLResponse(
+                  url: url, statusCode: stub.status, httpVersion: "HTTP/1.1", headerFields: nil)
+        else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+            return
+        }
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        if !stub.body.isEmpty { client?.urlProtocol(self, didLoad: stub.body) }
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+}
+
 // Context API tests - pure Swift implementation
 public final class ContextTests: TestImplementation {
 
@@ -312,7 +373,12 @@ public final class ContextTests: TestImplementation {
 
     public func testHTTPResolverErrorFailsRead() -> TestResult {
         let name = "HTTP Resolver Error Fails Read"
-        struct ResolverRefused: Error {}
+        // Carries a distinctive localized message so the assertion below can tell the
+        // resolver's own error text apart from a reflected description of the error case.
+        struct ResolverRefused: LocalizedError {
+            static let message = "resolver refused this request on purpose"
+            var errorDescription: String? { Self.message }
+        }
         do {
             let (asset, _) = try signWithRemoteManifest()
             let requests = CallbackRecorder<HTTPRequest>()
@@ -324,11 +390,127 @@ public final class ContextTests: TestImplementation {
             do {
                 _ = try Reader(context: context, format: "image/jpeg", stream: try Stream(data: asset))
                 return .failure(name, "read succeeded although the resolver threw")
-            } catch is C2PAError {
+            } catch let error as C2PAError {
                 guard requests.recorded.count == 1 else {
                     return .failure(name, "resolver was called \(requests.recorded.count) times, expected 1")
                 }
-                return .success(name, "[PASS] resolver error surfaced as C2PAError from the read")
+                let text = error.localizedDescription
+                guard text.contains(ResolverRefused.message) else {
+                    return .failure(name, "resolver error text did not reach the caller: \(text)")
+                }
+                return .success(name, "[PASS] resolver error text surfaced: \(text)")
+            }
+        } catch {
+            return .failure(name, "Error: \(error)")
+        }
+    }
+
+    public func testHTTPResolverRejectsOutOfRangeStatus() -> TestResult {
+        let name = "HTTP Resolver Out Of Range Status"
+        do {
+            let (asset, manifest) = try signWithRemoteManifest()
+            let context = try remoteFetchContext { _ in
+                // Past Int32: narrowing this unguarded would trap inside the C callback,
+                // aborting the process where no Swift frame could catch it.
+                HTTPResponse(status: Int(Int32.max) + 1, body: manifest)
+            }
+
+            do {
+                _ = try Reader(context: context, format: "image/jpeg", stream: try Stream(data: asset))
+                return .failure(name, "read succeeded although the status was out of range")
+            } catch let error as C2PAError {
+                let text = error.localizedDescription
+                guard text.contains("out of range") else {
+                    return .failure(name, "unexpected error for an out-of-range status: \(text)")
+                }
+                return .success(name, "[PASS] out-of-range status refused: \(text)")
+            }
+        } catch {
+            return .failure(name, "Error: \(error)")
+        }
+    }
+
+    public func testURLSessionResolverRejectsMainQueueSession() -> TestResult {
+        let name = "URLSession Resolver Rejects Main Queue"
+        // Blocking on a session that completes on the main queue deadlocks whenever the
+        // operation itself runs there, so the initializer refuses it up front.
+        let session = URLSession(configuration: .ephemeral, delegate: nil, delegateQueue: .main)
+        defer { session.invalidateAndCancel() }
+        do {
+            _ = try C2PAContext(urlSession: session)
+            return .failure(name, "context was created with a main-queue session")
+        } catch let error as C2PAError {
+            guard error.localizedDescription.contains("main queue") else {
+                return .failure(name, "unexpected error: \(error.localizedDescription)")
+            }
+            return .success(name, "[PASS] main-queue session refused")
+        } catch {
+            return .failure(name, "Error: \(error)")
+        }
+    }
+
+    public func testURLSessionResolverFetchesRemoteManifest() -> TestResult {
+        let name = "URLSession Resolver Remote Manifest Fetch"
+        do {
+            let (asset, manifest) = try signWithRemoteManifest()
+            StubURLProtocol.state.stub(status: 200, body: manifest)
+
+            let configuration = URLSessionConfiguration.ephemeral
+            configuration.protocolClasses = [StubURLProtocol.self]
+            // No delegate queue, so URLSession makes its own background one and the
+            // blocking resolver has something to be woken by.
+            let session = URLSession(configuration: configuration)
+            defer { session.invalidateAndCancel() }
+
+            let settings = try C2PASettings(
+                json: "{\"version\": 1, \"verify\": {\"remote_manifest_fetch\": true}}")
+            let context = try C2PAContext(settings: settings, urlSession: session)
+
+            let reader = try Reader(
+                context: context, format: "image/jpeg", stream: try Stream(data: asset))
+            let json = try reader.json()
+
+            let seen = StubURLProtocol.state.recorded
+            guard seen.count == 1, let request = seen.first else {
+                return .failure(name, "expected exactly one HTTP request, got \(seen.count)")
+            }
+            guard request.url == Self.remoteManifestURL else {
+                return .failure(name, "requested \(String(describing: request.url))")
+            }
+            guard request.httpMethod == "GET" else {
+                return .failure(name, "used method \(String(describing: request.httpMethod))")
+            }
+            guard let store = try JSONSerialization.jsonObject(with: Data(json.utf8)) as? [String: Any],
+                  let active = store["active_manifest"] as? String,
+                  let manifests = store["manifests"] as? [String: Any],
+                  let fetched = manifests[active] as? [String: Any],
+                  let assertions = fetched["assertions"] as? [[String: Any]],
+                  assertions.contains(where: { $0["label"] as? String == "c2pa.test" })
+            else {
+                return .failure(name, "fetched manifest did not round-trip: \(json.prefix(300))")
+            }
+            return .success(name, "[PASS] URLSession resolver served \(manifest.count) bytes")
+        } catch {
+            return .failure(name, "Error: \(error)")
+        }
+    }
+
+    public func testHTTPResolverEmptyResponseBody() -> TestResult {
+        let name = "HTTP Resolver Empty Response Body"
+        do {
+            let (asset, _) = try signWithRemoteManifest()
+            // A zero-length body sends a null pointer across the boundary. The read cannot
+            // succeed without a manifest; what matters is that it fails rather than crashes.
+            let context = try remoteFetchContext { _ in
+                HTTPResponse(status: 204, body: Data())
+            }
+
+            do {
+                _ = try Reader(
+                    context: context, format: "image/jpeg", stream: try Stream(data: asset))
+                return .failure(name, "read succeeded although the resolver served no manifest")
+            } catch is C2PAError {
+                return .success(name, "[PASS] empty response body surfaced as an error")
             }
         } catch {
             return .failure(name, "Error: \(error)")
@@ -347,7 +529,11 @@ public final class ContextTests: TestImplementation {
             testURLSessionHTTPResolver(),
             testContextWithSettingsAndCallbacks(),
             testHTTPResolverRemoteManifestFetch(),
-            testHTTPResolverErrorFailsRead()
+            testHTTPResolverErrorFailsRead(),
+            testHTTPResolverRejectsOutOfRangeStatus(),
+            testURLSessionResolverRejectsMainQueueSession(),
+            testURLSessionResolverFetchesRemoteManifest(),
+            testHTTPResolverEmptyResponseBody()
         ]
     }
 }


### PR DESCRIPTION
## Changes in this pull request
<!-- Give a description of what has changed -->
Adds progress and HTTP resolver callbacks to `C2PAContext` as defaulted initializer parameters, wrapping `c2pa_context_builder_set_progress_callback` and `c2pa_http_resolver_create`. Progress is observe-only (cancellation stays with `cancel()`), and a separate initializer takes a `URLSession` instead of a custom resolver. `init()` and `init(settings:)` collapse into the new initializer; all existing call sites resolve unchanged.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] All applicable changes have been documented
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment